### PR TITLE
Fix type annotations for list_artifacts method

### DIFF
--- a/mlflow/store/artifact/artifact_repo.py
+++ b/mlflow/store/artifact/artifact_repo.py
@@ -8,7 +8,7 @@ from abc import ABC, ABCMeta, abstractmethod
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, Optional, List
 
 from mlflow.entities.file_info import FileInfo
 from mlflow.entities.multipart_upload import CreateMultipartUploadResponse, MultipartUploadPart
@@ -151,7 +151,7 @@ class ArtifactRepository:
         """
 
     @abstractmethod
-    def list_artifacts(self, path):
+    def list_artifacts(self, path: Optional[str] = None) -> List:
         """
         Return all the artifacts for this run_id directly under path. If path is a file, returns
         an empty list. Will error if path is neither a file nor directory.
@@ -162,6 +162,7 @@ class ArtifactRepository:
         Returns:
             List of artifacts as FileInfo listed directly under path.
         """
+        raise NotImplementedError
 
     def _is_directory(self, artifact_path):
         listing = self.list_artifacts(artifact_path)

--- a/mlflow/store/artifact/databricks_artifact_repo.py
+++ b/mlflow/store/artifact/databricks_artifact_repo.py
@@ -4,7 +4,7 @@ import logging
 import os
 import posixpath
 import uuid
-from typing import Any
+from typing import Any, Optional, List
 
 import requests
 
@@ -720,7 +720,7 @@ class DatabricksArtifactRepository(CloudArtifactRepository):
             artifact_file_path=artifact_file_path,
         )
 
-    def list_artifacts(self, path=None):
+    def list_artifacts(self, path: Optional[str] = None) -> List:
         if path:
             run_relative_path = posixpath.join(self.run_relative_artifact_repo_root_path, path)
         else:

--- a/mlflow/store/artifact/databricks_models_artifact_repo.py
+++ b/mlflow/store/artifact/databricks_models_artifact_repo.py
@@ -2,6 +2,7 @@ import json
 import logging
 import os
 import posixpath
+from typing import Optional, List
 
 import mlflow.tracking
 from mlflow.entities import FileInfo
@@ -84,7 +85,7 @@ class DatabricksModelsArtifactRepository(ArtifactRepository):
             body["page_token"] = page_token
         return body
 
-    def list_artifacts(self, path=None):
+    def list_artifacts(self, path: Optional[str] = None) -> List[FileInfo]:
         infos = []
         page_token = None
         if not path:

--- a/mlflow/store/artifact/databricks_sdk_models_artifact_repo.py
+++ b/mlflow/store/artifact/databricks_sdk_models_artifact_repo.py
@@ -1,5 +1,5 @@
 import posixpath
-
+from typing import Optional, List
 from mlflow.entities import FileInfo
 from mlflow.store.artifact.cloud_artifact_repo import CloudArtifactRepository
 
@@ -25,7 +25,7 @@ class DatabricksSDKModelsArtifactRepository(CloudArtifactRepository):
         self.client = _get_databricks_workspace_client()
         super().__init__(self.model_base_path)
 
-    def list_artifacts(self, path=None):
+    def list_artifacts(self, path: Optional[str] = None) -> List[FileInfo]:
         dest_path = self.model_base_path
         if path:
             dest_path = posixpath.join(dest_path, path)

--- a/mlflow/store/artifact/dbfs_artifact_repo.py
+++ b/mlflow/store/artifact/dbfs_artifact_repo.py
@@ -1,6 +1,7 @@
 import json
 import os
 import posixpath
+from typing import Optional, List
 
 import mlflow.utils.databricks_utils
 from mlflow.entities import FileInfo
@@ -131,7 +132,7 @@ class DbfsRestArtifactRepository(ArtifactRepository):
                 file_path = os.path.join(dirpath, name)
                 self.log_artifact(file_path, artifact_subdir)
 
-    def list_artifacts(self, path=None):
+    def list_artifacts(self, path: Optional[str] = None) -> List:
         dbfs_path = self._get_dbfs_path(path) if path else self._get_dbfs_path("")
         dbfs_list_json = {"path": dbfs_path}
         response = self._dbfs_list_api(dbfs_list_json)


### PR DESCRIPTION
Updated type annotations and added `NotImplementedError` to `list_artifacts` methods.

* **mlflow/store/artifact/artifact_repo.py**
  - Updated `list_artifacts` method signature to include type annotations.
  - Added `NotImplementedError` to `list_artifacts` method.
* **mlflow/store/artifact/databricks_artifact_repo.py**
  - Updated `list_artifacts` method signature to include type annotations.
* **mlflow/store/artifact/databricks_models_artifact_repo.py**
  - Updated `list_artifacts` method signature to include type annotations.
* **mlflow/store/artifact/databricks_sdk_models_artifact_repo.py**
  - Updated `list_artifacts` method signature to include type annotations.
* **mlflow/store/artifact/dbfs_artifact_repo.py**
  - Updated `list_artifacts` method signature to include type annotations.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/benglewis/mlflow/pull/1?shareId=eca58953-62d6-42d6-8f59-cc56450f2f1e).